### PR TITLE
feat(fretamento2): Novas features

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.1.3*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.2.1*
 
 > A library for using generic layer maps 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inlog/inlog-maps",
-  "version": "4.1.4",
+  "version": "4.2.1",
   "description": "A library for using generic layer maps ",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/models/apis/googleMaps.ts
+++ b/src/models/apis/googleMaps.ts
@@ -328,6 +328,9 @@ export default class GoogleMaps implements IMapFunctions {
                 case MarkerEventType.MouseOver:
                     this.google.maps.event.clearListeners(marker, 'mouseover');
                     break;
+                case MarkerEventType.MouseOut:
+                    this.google.maps.event.clearListeners(marker, 'mouseout');
+                    break;
                 default:
                     break;
             }

--- a/src/models/apis/googleMaps.ts
+++ b/src/models/apis/googleMaps.ts
@@ -302,6 +302,12 @@ export default class GoogleMaps implements IMapFunctions {
                         eventFunction(marker, param, marker.object);
                     });
                     break;
+                case MarkerEventType.MouseOut:
+                    this.google.maps.event.addListener(marker, 'mouseout', (event: any) => {
+                        const param = new EventReturn([event.latLng.lat(), event.latLng.lng()]);
+                        eventFunction(marker, param, marker.object);
+                    });
+                    break;
                 default:
                     break;
             }
@@ -771,10 +777,11 @@ export default class GoogleMaps implements IMapFunctions {
         polylines.forEach((polyline: any) => {
             switch (eventType) {
                 case PolylineEventType.Move:
-                    this.google.maps.event.addListener(polyline.getPath(), 'set_at', (event: any) => {
-                        const param = new EventReturn([polyline.getPath()
-                            .getAt(event).lat(), polyline.getPath().getAt(event).lng()]);
-                        eventFunction(param);
+                    this.google.maps.event.addListener(polyline.getPath(), 'set_at', (newEvent: any, lastEvent: any) => {
+                        const newPosition = new EventReturn([polyline.getPath()
+                            .getAt(newEvent).lat(), polyline.getPath().getAt(newEvent).lng()]);
+                        const lastPosition = new EventReturn([lastEvent.lat(), lastEvent.lng()]);
+                        eventFunction(newPosition, lastPosition);
                     });
                     break;
                 case PolylineEventType.InsertAt:

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -241,6 +241,12 @@ export default class Leaflet implements IMapFunctions {
                         eventFunction(marker, param, marker.object);
                     });
                     break;
+                case MarkerEventType.MouseOut:
+                    marker.on('mouseout', (event: any) => {
+                        const param = new EventReturn([event.latlng.lat, event.latlng.lng]);
+                        eventFunction(marker, param, marker.object);
+                    });
+                    break;
                 default:
                     break;
             }
@@ -696,15 +702,18 @@ export default class Leaflet implements IMapFunctions {
         polylines.forEach((polyline: any) => {
             switch (eventType) {
                 case PolylineEventType.Move:
-                    polyline.on('editable:vertex:dragstart', (event: any) => {
-                        const param = new EventReturn([event.vertex.latlng.lat, event.vertex.latlng.lng]);
-                        eventFunction(param);
+                    polyline.on('editable:vertex:dragend', (event: any) => {
+                        const newPosition = new EventReturn([event.vertex.latlng.lat, event.vertex.latlng.lng]);
+                        const lastPosition = new EventReturn([event.vertex.latlngs[0].lat, event.vertex.latlngs[0].lng]);
+                        eventFunction(newPosition, lastPosition);
                     });
                     break;
                 case PolylineEventType.InsertAt:
-                    polyline.on('editable:vertex:dragend', (event: any) => {
-                        const param = new EventReturn([event.vertex.latlng.lat, event.vertex.latlng.lng]);
-                        eventFunction(param);
+                    polyline.on('editable:vertex:new', () => {
+                        polyline.on('editable:vertex:dragend', (event: any) => {
+                            const param = new EventReturn([event.vertex.latlng.lat, event.vertex.latlng.lng]);
+                            eventFunction(param);
+                        });
                     });
                     break;
                 case PolylineEventType.RemoveAt:

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -554,6 +554,7 @@ export default class Leaflet implements IMapFunctions {
         }
 
         const polyline = new this.leaflet.Polyline(options.path || [], newOptions);
+        polyline.on('editable:vertex:rawclick', (e) => e.cancel() );
 
         if (eventClick) {
             polyline.on('click', (event: any) => {

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -265,6 +265,9 @@ export default class Leaflet implements IMapFunctions {
                 case MarkerEventType.MouseOver:
                     marker.off('mouseover');
                     break;
+                case MarkerEventType.MouseOut:
+                    marker.off('mouseout');
+                    break;
                 default:
                     break;
             }
@@ -737,9 +740,10 @@ export default class Leaflet implements IMapFunctions {
         polylines.forEach((polyline: any) => {
             switch (event) {
                 case PolylineEventType.Move:
-                    polyline.off('editable:vertex:dragstart');
+                    polyline.off('editable:vertex:dragend');
                     break;
                 case PolylineEventType.InsertAt:
+                    polyline.off('editable:vertex:new');
                     polyline.off('editable:vertex:dragend');
                     break;
                 case PolylineEventType.RemoveAt:

--- a/src/models/dto/event-type.ts
+++ b/src/models/dto/event-type.ts
@@ -6,7 +6,8 @@ export enum MapEventType {
 export enum MarkerEventType {
     Click,
     AfterDrag,
-    MouseOver
+    MouseOver,
+    MouseOut
 }
 
 export enum CircleEventType {


### PR DESCRIPTION
Nessa PR terá alguns novos recursos necessários para o Fretamento. Segue a descrição dos itens já adicionados e os que devo lançar nos próximos dias.

- [x] Adição no MarkerEventType: MouseOut.
- [x] Melhoria na padronização dos PolylineEventTypes.
- [x] Bloquear comportamento no Leaflet.Editable de deletar um vertex ao clicar nele.
- [x] Opção de mudança do cursor sobre o mapa. Ex: trocar cursor para formato de marcador quando a opção de "adicionar marcador" for selecionada.
- [x] Retornar listerners específicos quando um elemento de InfoWindow for disparado.

Descrevendo melhor o segundo item.
No Google Maps, existem [3 listerners disponíveis](https://developers.google.com/maps/documentation/javascript/shapes#polyline_inspect) para a manipulação de uma polyline: insert_at, remove_at e set_at. Porém no [Leaflet.Editable](http://leaflet.github.io/Leaflet.Editable/doc/api.html#editable-vertex-events), não existem features exatamente iguais. A implementação anterior, as features PolylineEventType.Move, PolylineEventType.InsertAt e PolylineEventType.RemoveAt não estavam bem sincronizadas nos dois mapas.
O que temos agora:
- PolylineEventType.Move: retorna a geolocalização dos ponto antes e depois de terminar de arrastar a polyline editável.
- PolylineEventType.InsertAt: retorna a geolocalização do novo ponto após terminar de arrastar.
- PolylineEventType.RemoveAt: retorna a geolocalização do ponto deletado.