### PR TITLE
fix(polyline): correção no click para Leaflet

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.2.6*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.2.7*
 
 > A library for using generic layer maps 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inlog/inlog-maps",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "A library for using generic layer maps ",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -576,6 +576,7 @@ export default class Leaflet implements IMapFunctions {
 
         if (eventClick) {
             polyline.on('click', (event: any) => {
+                self.leaflet.DomEvent.stopPropagation(event);
                 const param = new EventReturn([event.latlng.lat, event.latlng.lng]);
                 eventClick(param, event.target.object);
             });


### PR DESCRIPTION
Apenas no Leaflet, estava tendo o seguinte problema. Ao receber o evento do click sobre uma polyline, estava disparando também o evento sobre o clique no mapa.

Essa correção é bem semelhante ao comportamento que já está presente no drawPolygon [nesta linha](https://github.com/weareinlog/inlog-maps/blob/master/src/models/apis/leaflet.ts#L328).

Thread com problema semelhante: https://github.com/Leaflet/Leaflet/issues/5313