### PR TITLE
feat(overlay): adição de alterOverlayOptions

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.2.7*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.2.8*
 
 > A library for using generic layer maps 
 
@@ -1465,7 +1465,7 @@ Returns the coordinates from pixels
 
 #### Map.drawOverlay(type, options) 
 
-Use this function to dray overlays on the current map
+Use this function to draw overlays on the current map
 
 
 
@@ -1500,6 +1500,31 @@ Use this function to show or hide overlay
 | ---- | ---- | ----------- | -------- |
 | show | `boolean`  |  | &nbsp; |
 | type | `string`  |  | &nbsp; |
+| condition | `any`  | [nullable] | &nbsp; |
+
+
+
+
+##### Returns
+
+
+- `Void`
+
+
+
+#### Map.alterOverlayOptions(type, options, condition) 
+
+Use this function to alter overlay options/style
+
+
+
+
+##### Parameters
+
+| Name | Type | Description |  |
+| ---- | ---- | ----------- | -------- |
+| type | `string`  |  | &nbsp; |
+| options | `InlogMaps.OverlayAlterOptions`  |  | &nbsp; |
 | condition | `any`  | [nullable] | &nbsp; |
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inlog/inlog-maps",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "A library for using generic layer maps ",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/demo.js
+++ b/src/demo.js
@@ -437,6 +437,21 @@ function addPolygon() {
     }
 }
 
+function changeOverlay() {
+    const div = document.createElement('div');
+    div.style.fontSize = '13px';
+    div.style.position = 'absolute';
+    div.style.minWidth = '90px';
+
+    const span = document.createElement('span');
+    span.textContent = String(Math.random());
+    div.appendChild(span);
+
+    const overlayOptions = new inlogMaps.OverlayOptions(div, true);
+    overlayOptions.polygon = 'polygon';
+    currentMap.alterOverlayOptions('ocupacao', overlayOptions);
+}
+
 function changePolygonColor() {
     if (polygonShow === null) {
         alert('The polygon was not created yet!');

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
         <input type="submit" value="Change Marker Custom Image" onclick="changeCustomMarkerImage()" />
         <input type="submit" value="Show/Hide Circle Marker" onclick="addCircleMarker()" />
         <input type="submit" value="Change Circle Marker Color" onclick="changeCircleMarkerColor()" />
-        
+
     </fieldset>
     <fieldset>
         Polylines:
@@ -34,6 +34,7 @@
         <input type="submit" value="Show/Hide Polygon" onclick="addPolygon()" />
         <input type="submit" value="Change Polygon Color" onclick="changePolygonColor()" />
         <input type="submit" value="Change Popup Value" onclick="changePopupValue()" />
+        <input type="submit" value="Change Overlay" onclick="changeOverlay()" />
     </fieldset>
     <fieldset>
         Circles:

--- a/src/map.ts
+++ b/src/map.ts
@@ -30,8 +30,8 @@ export default class Map {
 
     /**
      * Use this to initialize map
-     * @param {InlogMaps.MapType} mapType  
-     * @param {any} options 
+     * @param {InlogMaps.MapType} mapType
+     * @param {any} options
      * @param {string} elementId default: 'inlog-map' [nullable]
      * @returns {Promisse<any>}
      */
@@ -199,7 +199,7 @@ export default class Map {
 
     /**
      * This functions returns if marker exists
-     * @param type 
+     * @param type
      * @param condition [nullable]
      * @returns {boolean}
      */
@@ -210,9 +210,9 @@ export default class Map {
 
     /**
      * Use this function to count markers by type
-     * @param {string} type 
+     * @param {string} type
      * @param {boolean} onlyOnMap exclude hidden markers, default true
-     * @param {any} condition 
+     * @param {any} condition
      * @returns {number}
      */
     public countMarkers(type: string, onlyOnMap: boolean = true, condition?: any): number {
@@ -230,9 +230,9 @@ export default class Map {
 
     /**
      * This function add new events on marker
-     * @param {string} type 
-     * @param {InlogMaps.MarkerEventType} event 
-     * @param {any} eventFunction 
+     * @param {string} type
+     * @param {InlogMaps.MarkerEventType} event
+     * @param {any} eventFunction
      * @param {any} condition [nullable]
      */
     public addMarkerEvent(type: string, event: MarkerEventType, eventFunction: any, condition?: any): void {
@@ -243,8 +243,8 @@ export default class Map {
 
     /**
      * This function remove events of marker
-     * @param {string} type 
-     * @param {InlogMaps.MarkerEventType} event 
+     * @param {string} type
+     * @param {InlogMaps.MarkerEventType} event
      * @param {any} condition [nullable]
      */
     public removeMarkerEvent(type: string, event: MarkerEventType, condition?: any): void {
@@ -257,7 +257,7 @@ export default class Map {
     /**
      * Use this function to add MarkerClusterer on the map
      * @param {string} type same type of markers
-     * @param {InlogMaps.MarkerClusterConfig} config 
+     * @param {InlogMaps.MarkerClusterConfig} config
      */
     public addMarkerClusterer(type: string, config: MarkerClustererConfig): void {
         this.markerClusterer[type] = this.map.addMarkerClusterer(config);
@@ -266,7 +266,7 @@ export default class Map {
     /**
      * Use this function to alter clusterer options
      * @param type same type of markers
-     * @param {InlogMaps.MarkerClusterConfig} config 
+     * @param {InlogMaps.MarkerClusterConfig} config
      */
     public alterMarkerClustererConfig(type: string, config: MarkerClustererConfig): void {
         if (this.markerClusterer[type]) {
@@ -394,7 +394,7 @@ export default class Map {
 
     /**
      * This functions returns if polygon exists
-     * @param type 
+     * @param type
      * @param condition [nullable]
      * @returns {boolean}
      */
@@ -405,9 +405,9 @@ export default class Map {
 
     /**
      * This function add new events on polygon
-     * @param {string} type 
-     * @param {InlogMaps.PolygonEventType} event 
-     * @param {any} eventFunction 
+     * @param {string} type
+     * @param {InlogMaps.PolygonEventType} event
+     * @param {any} eventFunction
      * @param {any} condition [nullable]
      */
     public addPolygonEvent(type: string, event: PolygonEventType, eventFunction: any, condition?: any): void {
@@ -418,8 +418,8 @@ export default class Map {
 
     /**
      * This function remove events of polygon
-     * @param {string} type 
-     * @param {InlogMaps.PolygonEventType} event 
+     * @param {string} type
+     * @param {InlogMaps.PolygonEventType} event
      * @param {any} condition [nullable]
      */
     public removePolygonEvent(type: string, event: PolygonEventType, condition?: any): void {
@@ -514,7 +514,7 @@ export default class Map {
 
     /**
      * This functions returns if circle exists
-     * @param {string} type 
+     * @param {string} type
      * @param {any} condition [nullable]
      * @returns {boolean}
      */
@@ -525,7 +525,7 @@ export default class Map {
 
     /**
      * This function return circle center
-     * @param {string} type 
+     * @param {string} type
      * @param {any} condition [nullable]
      * @returns {number[]}
      */
@@ -541,9 +541,9 @@ export default class Map {
 
     /**
      * This function add new events on circle
-     * @param {string} type 
-     * @param {InlogMaps.CircleEventType} event 
-     * @param {any} eventFunction 
+     * @param {string} type
+     * @param {InlogMaps.CircleEventType} event
+     * @param {any} eventFunction
      * @param {any} condition [nullable]
      */
     public addCircleEvent(type: string, event: CircleEventType, eventFunction: any, condition?: any): void {
@@ -554,8 +554,8 @@ export default class Map {
 
     /**
      * This function remove events of circle
-     * @param {string} type 
-     * @param {InlogMaps.CircleEventType} event 
+     * @param {string} type
+     * @param {InlogMaps.CircleEventType} event
      * @param {any} condition [nullable]
      */
     public removeCircleEvent(type: string, event: CircleEventType, condition?: any): void {
@@ -610,7 +610,7 @@ export default class Map {
 
     /**
      * Use this function to remove polylines
-     * @param {string} type 
+     * @param {string} type
      * @param {any} condition remove polyline with the condition [nullable]
      */
     public removePolylines(type: string, condition?: any): void {
@@ -637,7 +637,7 @@ export default class Map {
     /**
      * Use this function to alter polyline options
      * @param {string} type
-     * @param {InlogMaps.PolylineOptions} options 
+     * @param {InlogMaps.PolylineOptions} options
      * @param {any} condition alter polyline with the condition [nullable]
      */
     public alterPolylineOptions(type: string, options: PolylineOptions, condition?: any): void {
@@ -701,9 +701,9 @@ export default class Map {
 
     /**
      * Use this function to add listeners on polyline
-     * @param {string} type 
-     * @param {InlogMaps.PolylineEventType} event 
-     * @param {any} eventFunction 
+     * @param {string} type
+     * @param {InlogMaps.PolylineEventType} event
+     * @param {any} eventFunction
      * @param {any} condition [nullable]
      */
     public addPolylineEvent(type: string, event: PolylineEventType, eventFunction: any, condition?: any): void {
@@ -714,8 +714,8 @@ export default class Map {
 
     /**
      * Use this function to remove listeners of polyline
-     * @param {string} type 
-     * @param {InlogMaps.PolylineEventType} event 
+     * @param {string} type
+     * @param {InlogMaps.PolylineEventType} event
      * @param {any} condition [nullable]
      */
     public removePolylineEvent(type: string, event: PolylineEventType, condition?: any): void {
@@ -726,8 +726,8 @@ export default class Map {
 
     /**
      * Use this function to set position of polyline highlight
-     * @param {string} type 
-     * @param {number} initialIndex 
+     * @param {string} type
+     * @param {number} initialIndex
      * @param {any} condition [nullable]
      */
     public setIndexPolylineHighlight(type: string, initialIndex: number, condition?: any) {
@@ -780,8 +780,8 @@ export default class Map {
     }
 
     /**
-     * 
-     * @param {string} type 
+     *
+     * @param {string} type
      * @returns {object}
      */
     public getObjectOpenPopup(type: string): object {
@@ -867,8 +867,8 @@ export default class Map {
 
     /**
      * Returns the coordinates from pixels
-     * @param {number} offsetx 
-     * @param {number} offsety 
+     * @param {number} offsetx
+     * @param {number} offsety
      * @returns {number[]}
      */
     public pixelsToLatLng(offsetx: number, offsety: number): number[] {
@@ -877,7 +877,7 @@ export default class Map {
 
     /* Overlay */
     /**
-     * Use this function to dray overlays on the current map
+     * Use this function to draw overlays on the current map
      * @param {string} type
      * @param {InlogMaps.OverlayOptions} options
      */
@@ -915,6 +915,22 @@ export default class Map {
             this.map.toggleOverlay(overlays, show);
         }
     }
+
+    /**
+     * Use this function to alter overlay options/style
+     * @param {string} type
+     * @param {InlogMaps.OverlayAlterOptions} options
+     * @param {any} condition [nullable]
+     */
+    public alterOverlayOptions(type: string, options: OverlayOptions, condition?: any): void {
+        const overlays = this.getOverlays(type, condition);
+
+        if (overlays && overlays.length) {
+            const polygons = this.getPolygons(options.polygon, options.conditionPolygon);
+            this.map.toggleOverlay(overlays, false);
+            this.overlayList[type] = this.map.alterOverlayOptions(overlays, options, polygons);
+        }
+    };
 
     /**
      * Remove overlays from the map and from internal list

--- a/src/models/apis/googleMaps.ts
+++ b/src/models/apis/googleMaps.ts
@@ -10,6 +10,7 @@ import CircleMarkerOptions from '../features/marker/circle-marker-options';
 import MarkerAlterOptions from '../features/marker/marker-alter-options';
 import MarkerOptions from '../features/marker/marker-options';
 import OverlayOptions from '../features/overlay/overlay-options';
+import OverlayAlterOptions from '../features/overlay/overlay-alter-options';
 import PolygonAlterOptions from '../features/polygons/polygon-alter-options';
 import PolygonOptions from '../features/polygons/polygon-options';
 import NavigationOptions from '../features/polyline/navigations-options';
@@ -1013,6 +1014,14 @@ export default class GoogleMaps implements IMapFunctions {
     public toggleOverlay(overlays: any[], show: boolean) {
         const self = this;
         overlays.forEach((overlay) => overlay.setMap(show ? self.map : null));
+    }
+
+    public alterOverlayOptions(overlays: any[], options: OverlayAlterOptions, polygons: any) {
+        return overlays.map(() => {
+            const overlay = new this.OverlayGoogle(this.getPolygonsBounds(polygons), options.divElement);
+            overlay.setMap(this.map);
+            return overlay;
+        });
     }
 
     /* Private Methods */

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -17,6 +17,7 @@ import PolylineOptions from '../features/polyline/polyline-options';
 import PopupOptions from '../features/popup/popup-options';
 import IMapFunctions from './mapFunctions';
 import MarkerClustererConfig from '../features/marker-clusterer/marker-clusterer-config';
+import OverlayAlterOptions from "../features/overlay/overlay-alter-options";
 
 export default class Leaflet implements IMapFunctions {
     private map = null;
@@ -939,6 +940,16 @@ export default class Leaflet implements IMapFunctions {
     public toggleOverlay(overlays: any[], show: boolean) {
         const self = this;
         overlays.forEach((overlay) => show ? self.map.addLayer(overlay) : self.map.removeLayer(overlay));
+    }
+
+    public alterOverlayOptions(overlays: any[], options: OverlayAlterOptions, polygons: any) {
+        return overlays.map(() => {
+            const html: string = options.divElement.outerHTML;
+            const myIcon = new this.leaflet.DivIcon({ html });
+            const overlay = new this.leaflet.Marker(this.getBoundsPolygons(polygons).getCenter(), { icon: myIcon });
+            overlay.addTo(this.map);
+            return overlay;
+        });
     }
 
     /* Private Methods */

--- a/src/models/apis/mapFunctions.ts
+++ b/src/models/apis/mapFunctions.ts
@@ -92,4 +92,5 @@ export default interface IMapFunctions {
     /* Overlay */
     drawOverlay(options: OverlayOptions, polygons?: any): any;
     toggleOverlay(overlays: any[], show: boolean): void;
+    alterOverlayOptions(overlays: any[], options: OverlayOptions, polygons?: any): any;
 }

--- a/src/models/features/overlay/overlay-alter-options.ts
+++ b/src/models/features/overlay/overlay-alter-options.ts
@@ -1,0 +1,7 @@
+export default class OverlayAlterOptions {
+    public divElement: HTMLDivElement;
+
+    constructor(divElement: HTMLDivElement) {
+        this.divElement = divElement;
+    }
+}


### PR DESCRIPTION
Nesta PR foi adicionado o recurso de alteração do estilo de uma overlay. Com atualização da documentação e adição de um exemplo do recurso.

Observações:
- basicamente as alterações ficam restritas ao que for criado em 'divElement'. Possíveis mudanças de latitude e longitude estarão associadas a localização do polígono. Assim, se o polígono for reposicionado e ocorrer a chamada de alterar o overlay, ele pegará a nova localização do poligono.
- por causa da decisão acima, deixei apenas 'divElement' em overlay-alter-options.ts. Se essa não for a lógica correta, só me avisar que atualizo.
- tem tb uma pequena correção de typo em drawOverlay.