### PR TITLE
fix(polyline): correção no retorno do event no clique

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.5.0*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.5.1*
 
 > A library for using generic layer maps 
 

--- a/src/map.d.ts
+++ b/src/map.d.ts
@@ -115,8 +115,9 @@ export default class Map {
      * Use this function to draw polylines with navigation on the currentMap
      * @param {string} type
      * @param {inlogMaps.PolylineOptions} options
+     * @param {any} eventClick
      */
-    drawPolylineWithNavigation(type: string, options: PolylineOptions): void;
+    drawPolylineWithNavigation(type: string, options: PolylineOptions, eventClick?: any): void;
     /**
      * Use this function to add more paths to a polyline
      * @param {string} type

--- a/src/map.js
+++ b/src/map.js
@@ -191,8 +191,8 @@ var Map = /** @class */ (function () {
      * @param {string} type
      * @param {inlogMaps.PolylineOptions} options
      */
-    Map.prototype.drawPolylineWithNavigation = function (type, options) {
-        var polyline = this.map.drawPolylineWithNavigation(options);
+    Map.prototype.drawPolylineWithNavigation = function (type, options, eventClick) {
+        var polyline = this.map.drawPolylineWithNavigation(options, eventClick);
         this.polylinesList[type] = polyline;
     };
     /**

--- a/src/models/apis/google/google-polylines.ts
+++ b/src/models/apis/google/google-polylines.ts
@@ -105,9 +105,10 @@ export default class GooglePolylines {
     public drawPolylineWithNavigation(options: PolylineOptions, eventClick?: any) {
         const polyline = this.drawPolyline(options, null);
 
+        polyline.navigationHandlerClick = eventClick;
         this.navigationOptions = options.navigateOptions;
         this.addNavigation(polyline);
-        polyline.navigationHandlerClick = eventClick;
+
         return polyline;
     }
 
@@ -290,7 +291,8 @@ export default class GooglePolylines {
         this.google.maps.event.addDomListener(document, 'keyup', this.onKeyUp.bind(this));
 
         if (polyline.navigationHandlerClick) {
-            polyline.navigationHandlerClick();
+          const param = new EventReturn([event.latLng.lat(), event.latLng.lng()]);
+          polyline.navigationHandlerClick(param, polyline.object);
         }
     }
 

--- a/src/models/apis/googleMaps.d.ts
+++ b/src/models/apis/googleMaps.d.ts
@@ -37,7 +37,7 @@ export default class GoogleMaps implements IMapFunctions {
     alterCircleOptions(circles: any[], options: CircleAlterOptions): void;
     drawPolyline(options: PolylineOptions, eventClick: any): any;
     togglePolyline(polyline: any, show: boolean): void;
-    drawPolylineWithNavigation(options: PolylineOptions): any;
+    drawPolylineWithNavigation(options: PolylineOptions, eventClick: any): any;
     clearListenersPolyline(polyline: any): void;
     addPolylinePath(polyline: any, position: number[]): void;
     removePolylineHighlight(): void;

--- a/src/models/apis/googleMaps.js
+++ b/src/models/apis/googleMaps.js
@@ -320,9 +320,9 @@ var GoogleMaps = /** @class */ (function () {
         var self = this;
         polyline.setMap(show ? self.map : null);
     };
-    GoogleMaps.prototype.drawPolylineWithNavigation = function (options) {
+    GoogleMaps.prototype.drawPolylineWithNavigation = function (options, eventClick) {
         var self = this;
-        var polyline = self.drawPolyline(options, null);
+        var polyline = self.drawPolyline(options, eventClick);
         self.addNavigation(polyline, options.navigateOptions);
         return polyline;
     };

--- a/src/models/apis/leaflet.d.ts
+++ b/src/models/apis/leaflet.d.ts
@@ -38,7 +38,7 @@ export default class Leaflet implements IMapFunctions {
     alterCircleOptions(circles: any[], options: CircleAlterOptions): void;
     drawPolyline(options: PolylineOptions, eventClick: any): any;
     togglePolyline(polyline: any, show: boolean): void;
-    drawPolylineWithNavigation(options: PolylineOptions): any;
+    drawPolylineWithNavigation(options: PolylineOptions, eventClick: any): any;
     clearListenersPolyline(polyline: any): void;
     addPolylinePath(polyline: any, position: number[]): void;
     removePolylineHighlight(): void;

--- a/src/models/apis/leaflet.js
+++ b/src/models/apis/leaflet.js
@@ -283,7 +283,7 @@ var Leaflet = /** @class */ (function () {
             self.map.removeLayer(polyline);
         }
     };
-    Leaflet.prototype.drawPolylineWithNavigation = function (options) {
+    Leaflet.prototype.drawPolylineWithNavigation = function (options, eventClick) {
         var polyline = this.drawPolyline(options, null);
         this.addNavigation(polyline, options.navigateOptions);
         return polyline;

--- a/src/models/apis/leaflet/leaflet-polylines.ts
+++ b/src/models/apis/leaflet/leaflet-polylines.ts
@@ -96,9 +96,9 @@ export default class LeafletPolylines {
     public drawPolylineWithNavigation(options: PolylineOptions, eventClick?: any) {
         const polyline = this.drawPolyline(options, null);
 
+        polyline.navigationHandlerClick = eventClick;
         this.navigationOptions = options.navigateOptions;
         this.addNavigation(polyline);
-        polyline.navigationHandlerClick = eventClick;
         return polyline;
     }
 
@@ -304,7 +304,8 @@ export default class LeafletPolylines {
         document.onkeyup = this.onKeyUp.bind(this);
 
         if (polyline.navigationHandlerClick) {
-            polyline.navigationHandlerClick();
+            const param = new EventReturn([event.latlng.lat, event.latlng.lng]);
+            polyline.navigationHandlerClick(param, event.target.object);
         }
     }
 

--- a/src/models/apis/mapFunctions.d.ts
+++ b/src/models/apis/mapFunctions.d.ts
@@ -23,7 +23,7 @@ export default interface IMapFunctions {
     alterPolygonOptions(polygons: any[], options: PolygonAlterOptions): any;
     drawPolyline(options: PolylineOptions, eventClick: any): any;
     togglePolyline(polyline: any, show: boolean): any;
-    drawPolylineWithNavigation(options: PolylineOptions): any;
+    drawPolylineWithNavigation(options: PolylineOptions, eventClick: any): any;
     clearListenersPolyline(polyline: any): any;
     addPolylinePath(polyline: any, position: number[]): any;
     removePolylineHighlight(): any;


### PR DESCRIPTION
Na implementação do drawPolylineWithNavigation, existe a função de clique na polyline. Porém este não retorna o evento com latitude e longitude.
Com esse ajuste, o retorno passa a ser igual ao do drawPolyline.