### PR TITLE
fix(polyline): ajuste no navigateByPoint

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.5.1*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.5.2*
 
 > A library for using generic layer maps 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inlog/inlog-maps",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "A library for using generic layer maps ",
   "main": "index.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,8 @@
   "contributors": [
     "Lidia Freitas <lidiafreitas.me@gmail.com>",
     "Gustavo Santos <gustavo.dev@outlook.com.br>",
-    "Herus Armstrong <herus02@gmail.com>"
+    "Herus Armstrong <herus02@gmail.com>",
+    "Kleber Silva <kleber7777@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/models/apis/google/google-polylines.ts
+++ b/src/models/apis/google/google-polylines.ts
@@ -107,6 +107,7 @@ export default class GooglePolylines {
 
         polyline.navigationHandlerClick = eventClick;
         this.navigationOptions = options.navigateOptions;
+        this.navigateByPoint = this.navigationOptions ? this.navigationOptions.navigateByPoint : true;
         this.addNavigation(polyline);
 
         return polyline;

--- a/src/models/apis/google/google-polylines.ts
+++ b/src/models/apis/google/google-polylines.ts
@@ -284,7 +284,6 @@ export default class GooglePolylines {
         polyline.initialIdx = index;
         polyline.finalIdx = index + 1;
 
-        this.navigateByPoint = this.navigationOptions ? this.navigationOptions.navigateByPoint : true;
         this.moveSelectedPath(polyline, this.navigationOptions);
         this.selectedPolyline = polyline;
 

--- a/src/models/apis/leaflet/leaflet-polylines.ts
+++ b/src/models/apis/leaflet/leaflet-polylines.ts
@@ -298,7 +298,6 @@ export default class LeafletPolylines {
         polyline.initialIdx = index;
         polyline.finalIdx = index + 1;
 
-        this.navigateByPoint = this.navigationOptions ? this.navigationOptions.navigateByPoint : true;
         this.moveSelectedPath(polyline, this.navigationOptions);
         this.selectedPolyline = polyline;
 

--- a/src/models/apis/leaflet/leaflet-polylines.ts
+++ b/src/models/apis/leaflet/leaflet-polylines.ts
@@ -98,6 +98,7 @@ export default class LeafletPolylines {
 
         polyline.navigationHandlerClick = eventClick;
         this.navigationOptions = options.navigateOptions;
+        this.navigateByPoint = this.navigationOptions ? this.navigationOptions.navigateByPoint : true;
         this.addNavigation(polyline);
         return polyline;
     }


### PR DESCRIPTION
Reparei em um comportamento errado com uma situação especifica.

Se peço para plotar uma drawPolylineWithNavigation com navigateOptions.navigateByPoint igual a true, a polilinha é gerada corretamente. Ao clicar no primeiro segmento, é destacado o primeiro infowindow e a navegação via teclado funciona corretamente.

![polyline2](https://user-images.githubusercontent.com/58300548/70653849-02daeb00-1c34-11ea-9cb6-769727fc3419.PNG)

Porém se, após plotar a drawPolylineWithNavigation, eu definir um segmento como ativo...
`currentMap.setIndexPolylineHighlight('polylineNavigation', 0)`

... o infowindow ativo passa a ser o segundo e nunca consigo acessar o primeiro. Nem mudando via teclado.
![polyline1](https://user-images.githubusercontent.com/58300548/70654481-29e5ec80-1c35-11ea-8318-d041cd004162.PNG)

Reparei que a variável self.navigateByPoint do trecho abaixo sempre chega como undefined se eu não clico diretamente na polilinha. Com a troca sugerida nos trechos alterados eu consigo obter a informação da flag navigateByPoint.

https://github.com/weareinlog/inlog-maps/blob/master/src/models/apis/google/google-polylines.ts#L486