### PR TITLE
fix(polyline): resetando directionForward após setIndexPolylineHighlight

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.5.2*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.5.3*
 
 > A library for using generic layer maps 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inlog/inlog-maps",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "A library for using generic layer maps ",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/models/apis/google/google-polylines.ts
+++ b/src/models/apis/google/google-polylines.ts
@@ -246,6 +246,7 @@ export default class GooglePolylines {
     }
 
     public setIndexPolylineHighlight(polyline: any, index: number) {
+        this.directionForward = false;
         polyline.initialIdx = index;
         polyline.finalIdx = index + 1;
 

--- a/src/models/apis/leaflet/leaflet-polylines.ts
+++ b/src/models/apis/leaflet/leaflet-polylines.ts
@@ -263,6 +263,7 @@ export default class LeafletPolylines {
     }
 
     public setIndexPolylineHighlight(polyline: any, index: number) {
+        this.directionForward = false;
         polyline.initialIdx = index;
         polyline.finalIdx = index + 1;
 


### PR DESCRIPTION
Mais uma pequena correção. Isso é necessário para a navegação via teclado quando temos várias polylineWithNavigation.

O valor default da variável directionForward é false. Ao ir avançando a navegação na primeira polilinha, a variável muda pra true. Mas quando solicito a troca para outra polilinha...

`currentMap.setIndexPolylineHighlight('outrapolilinha', 0);`

... a variável continuava como true. Assim o ponto destacado estava sendo o 1 e não o 0.

A solução é resetar a variável na solicitação de setIndexPolylineHighlight.