### PR TITLE
fix(markerclustererplus): correção da importação da biblioteca do google

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -155,6 +155,22 @@ Remove markers from the map and from internal list
 
 
 
+#### Map.removeAllMarkers() 
+
+Remove all markers from the map and from the internal list
+
+
+
+
+
+
+##### Returns
+
+
+- `Void`
+
+
+
 #### Map.alterMarkerOptions(type, options, condition) 
 
 Use this function to alter marker style
@@ -523,6 +539,22 @@ Remove polygons from the map and from internal list
 
 
 
+#### Map.removeAllPolygons() 
+
+Remove all polygons from the map and from the internal list
+
+
+
+
+
+
+##### Returns
+
+
+- `Void`
+
+
+
 #### Map.alterPolygonOptions(type, options, condition) 
 
 Use this function to alter polygons options/style
@@ -734,6 +766,22 @@ Remove circles from the map and from internal list
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove circles with the condition [nullable] | &nbsp; |
+
+
+
+
+##### Returns
+
+
+- `Void`
+
+
+
+#### Map.removeAllCircles() 
+
+Remove all circles from the map and from the internal list
+
+
 
 
 
@@ -980,6 +1028,22 @@ Use this function to remove polylines
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove polyline with the condition [nullable] | &nbsp; |
+
+
+
+
+##### Returns
+
+
+- `Void`
+
+
+
+#### Map.removeAllPolylines() 
+
+Remove all polylines from the map and from the internal list
+
+
 
 
 
@@ -1637,6 +1701,22 @@ Remove overlays from the map and from internal list
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove overlays with the condition [nullable] | &nbsp; |
+
+
+
+
+##### Returns
+
+
+- `Void`
+
+
+
+#### Map.removeAllOverlays() 
+
+Remove all overlays from the map and from the internal list
+
+
 
 
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.6.0*
+# [@inlog/inlog-maps](https://github.com/weareinlog/inlog-maps#readme) *4.6.1*
 
 > A library for using generic layer maps 
 
@@ -144,22 +144,6 @@ Remove markers from the map and from internal list
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove markers with the condition [nullable] | &nbsp; |
-
-
-
-
-##### Returns
-
-
-- `Void`
-
-
-
-#### Map.removeAllMarkers() 
-
-Remove all markers from the map and from the internal list
-
-
 
 
 
@@ -539,22 +523,6 @@ Remove polygons from the map and from internal list
 
 
 
-#### Map.removeAllPolygons() 
-
-Remove all polygons from the map and from the internal list
-
-
-
-
-
-
-##### Returns
-
-
-- `Void`
-
-
-
 #### Map.alterPolygonOptions(type, options, condition) 
 
 Use this function to alter polygons options/style
@@ -766,22 +734,6 @@ Remove circles from the map and from internal list
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove circles with the condition [nullable] | &nbsp; |
-
-
-
-
-##### Returns
-
-
-- `Void`
-
-
-
-#### Map.removeAllCircles() 
-
-Remove all circles from the map and from the internal list
-
-
 
 
 
@@ -1028,22 +980,6 @@ Use this function to remove polylines
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove polyline with the condition [nullable] | &nbsp; |
-
-
-
-
-##### Returns
-
-
-- `Void`
-
-
-
-#### Map.removeAllPolylines() 
-
-Remove all polylines from the map and from the internal list
-
-
 
 
 
@@ -1701,22 +1637,6 @@ Remove overlays from the map and from internal list
 | ---- | ---- | ----------- | -------- |
 | type | `string`  |  | &nbsp; |
 | condition | `any`  | remove overlays with the condition [nullable] | &nbsp; |
-
-
-
-
-##### Returns
-
-
-- `Void`
-
-
-
-#### Map.removeAllOverlays() 
-
-Remove all overlays from the map and from the internal list
-
-
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inlog/inlog-maps",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "A library for using generic layer maps ",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/demo.js
+++ b/src/demo.js
@@ -11,10 +11,12 @@ const leafletLibParams = {
     scriptsDependencies: [
         '../node_modules/leaflet-editable/src/Leaflet.Editable.js',
         '../node_modules/leaflet.path.drag/src/Path.Drag.js',
-        '../node_modules/leaflet-gesture-handling/dist/leaflet-gesture-handling.js'
+        '../node_modules/leaflet-gesture-handling/dist/leaflet-gesture-handling.js',
+        '../node_modules/leaflet.markercluster/dist/leaflet.markercluster.js'
     ],
     cssDependencies: [
-        '../node_modules/leaflet-gesture-handling/dist/leaflet-gesture-handling.css'
+        '../node_modules/leaflet-gesture-handling/dist/leaflet-gesture-handling.css',
+        '../node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css'
     ],
     wikimedia: true
     // gestureHandling: true
@@ -259,6 +261,38 @@ function changeCircleMarkerColor() {
         options.style = style;
         currentMap.alterMarkerOptions('circleMarker', options);
     }
+}
+
+function addMarkerClusterer() {
+    const path = [
+        [-23.026949270121056, -43.48603893506065],
+        [-23.024657518124023, -43.48285071469786],
+        [-23.02484265813435, -43.48359100438597],
+        [-23.025441015571875, -43.48343945957663],
+        [-23.02518922621311, -43.48251677967551],
+        [-23.02535214879308, -43.482527508511566],
+        [-23.025524945253615, -43.48268307663443],
+        [-23.025618748953754, -43.483053221478485],
+        [-23.025692804460373, -43.48372377373221],
+        [-23.025762332433345, -43.484101627160385],
+        [-23.025828982320164, -43.484316203881576],
+        [-23.025944178594504, -43.484607520870725],
+        [-23.025988611796098, -43.48474163132147],
+        [-23.026284415679036, -43.485281467437744],
+        [-23.026438676263012, -43.485623602168175],
+        [-23.025967191451137, -43.48567456413946],
+        [-23.025775881698536, -43.48496646095953],
+        [-23.025542347567463, -43.48405234610573],
+        [-23.02516960068853, -43.484262899513396],
+        [-23.024949270121056, -43.48403893506065]
+    ];
+
+    currentMap.addMarkerClusterer('marker', new inlogMaps.MarkerClustererConfig(true, 13, 30));
+    path.forEach(p => {
+        let options = new inlogMaps.MarkerOptions(p, true, true, null, true);
+        options.addClusterer = true;
+        currentMap.drawMarker('marker', options);
+    });
 }
 
 function onZoomChanged() {

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
         <input type="submit" value="Change Marker Custom Image" onclick="changeCustomMarkerImage()" />
         <input type="submit" value="Show/Hide Circle Marker" onclick="addCircleMarker()" />
         <input type="submit" value="Change Circle Marker Color" onclick="changeCircleMarkerColor()" />
-        
+        <input type="submit" value="Show markers clustering" onclick="addMarkerClusterer()" />
     </fieldset>
     <fieldset>
         Polylines:

--- a/src/models/apis/google/google-markers.ts
+++ b/src/models/apis/google/google-markers.ts
@@ -4,7 +4,7 @@ import MarkerClustererConfig from '../../features/marker-clusterer/marker-cluste
 import CircleMarkerOptions from '../../features/marker/circle-marker-options';
 import MarkerAlterOptions from '../../features/marker/marker-alter-options';
 import MarkerOptions from '../../features/marker/marker-options';
-const MarkerClusterer = require('@google/markerclustererplus');
+const MarkerClusterer = require('../../../../node_modules/@google/markerclustererplus');
 
 export default class GoogleMarkers {
     private map = null;


### PR DESCRIPTION
Hotfix para corrigir o problema da importação da biblioteca markerclustererplus do Google Maps. Além disso, adiciona um exemplo de como implementar o addMarkerClusterer.