### PR TITLE
feat: v6.7.0 — suprimir popup de navegação...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@inlog/inlog-maps",
-    "version": "6.6.0",
+    "version": "6.7.0",
     "description": "A library for using generic layer maps ",
     "main": "index.js",
     "types": "dist/index.d.ts",

--- a/src/map.d.ts
+++ b/src/map.d.ts
@@ -117,7 +117,7 @@ export default class Map {
      * @param {inlogMaps.PolylineOptions} options
      * @param {any} eventClick
      */
-    drawPolylineWithNavigation(type: string, options: PolylineOptions, eventClick?: any): void;
+    drawPolylineWithNavigation(type: string, options: PolylineOptions, eventClick?: any, onNavigationPopupClose?: () => void): void;
     /**
      * Use this function to add more paths to a polyline
      * @param {string} type
@@ -128,6 +128,7 @@ export default class Map {
      * Use this function to clear polyline selected from the currentMap
      */
     removePolylineHighlight(): void;
+    setSuppressNavigationPopup(suppress: boolean): void;
     /**
      * Use this function to toggle polylines
      * @param {boolean} show

--- a/src/map.js
+++ b/src/map.js
@@ -635,9 +635,9 @@ var Map = /** @class */ (function () {
      * @param {string} type
      * @param {InlogMaps.PolylineOptions} options
      */
-    Map.prototype.drawPolylineWithNavigation = function (type, options, eventClick) {
+    Map.prototype.drawPolylineWithNavigation = function (type, options, eventClick, onNavigationPopupClose) {
         var _a;
-        var polyline = (_a = this.map) === null || _a === void 0 ? void 0 : _a.drawPolylineWithNavigation(options, eventClick);
+        var polyline = (_a = this.map) === null || _a === void 0 ? void 0 : _a.drawPolylineWithNavigation(options, eventClick, onNavigationPopupClose);
         if (!this.polylinesList[type]) {
             this.polylinesList[type] = [];
         }
@@ -762,6 +762,10 @@ var Map = /** @class */ (function () {
     Map.prototype.removePolylineHighlight = function () {
         var _a;
         (_a = this.map) === null || _a === void 0 ? void 0 : _a.removePolylineHighlight();
+    };
+    Map.prototype.setSuppressNavigationPopup = function (suppress) {
+        var _a;
+        (_a = this.map) === null || _a === void 0 ? void 0 : _a.setSuppressNavigationPopup(suppress);
     };
     /**
      * Use this function to add listeners on polyline

--- a/src/map.ts
+++ b/src/map.ts
@@ -788,11 +788,13 @@ export default class Map {
     public drawPolylineWithNavigation(
         type: string,
         options: PolylineOptions,
-        eventClick?: any
+        eventClick?: any,
+        onNavigationPopupClose?: () => void
     ): void {
         const polyline = this.map?.drawPolylineWithNavigation(
             options,
-            eventClick
+            eventClick,
+            onNavigationPopupClose
         );
 
         if (!this.polylinesList[type]) {
@@ -956,6 +958,10 @@ export default class Map {
      */
     public removePolylineHighlight(): void {
         this.map?.removePolylineHighlight();
+    }
+
+    public setSuppressNavigationPopup(suppress: boolean): void {
+        this.map?.setSuppressNavigationPopup(suppress);
     }
 
     /**

--- a/src/models/apis/google/google-polylines.js
+++ b/src/models/apis/google/google-polylines.js
@@ -14,6 +14,7 @@ var GooglePolylines = /** @class */ (function () {
         this.multiSelection = false;
         this.navigateByPoint = false;
         this.navigationOptions = {};
+        this.suppressNavigationPopup = false;
         this.map = map;
         this.google = google;
         this.googlePopups = googlePopups;
@@ -108,13 +109,14 @@ var GooglePolylines = /** @class */ (function () {
         }
         return polyline;
     };
-    GooglePolylines.prototype.drawPolylineWithNavigation = function (options, eventClick) {
+    GooglePolylines.prototype.drawPolylineWithNavigation = function (options, eventClick, onNavigationPopupClose) {
         var polyline = this.drawPolyline(options, null);
         polyline.navigationHandlerClick = eventClick;
         this.navigationOptions = options.navigateOptions;
         this.navigateByPoint = this.navigationOptions
             ? this.navigationOptions.navigateByPoint
             : true;
+        this.navigationPopupCloseHandler = onNavigationPopupClose || null;
         this.addNavigation(polyline);
         return polyline;
     };
@@ -232,6 +234,13 @@ var GooglePolylines = /** @class */ (function () {
         }
         if (this.navigateInfoWindow) {
             this.navigateInfoWindow.close();
+        }
+    };
+    GooglePolylines.prototype.setSuppressNavigationPopup = function (suppress) {
+        this.suppressNavigationPopup = suppress;
+        if (suppress && this.navigateInfoWindow) {
+            this.navigateInfoWindow.close();
+            this.navigateInfoWindow = null;
         }
     };
     GooglePolylines.prototype.addPolylineEvent = function (polylines, eventType, eventFunction) {
@@ -399,9 +408,7 @@ var GooglePolylines = /** @class */ (function () {
         }
         else {
             self.multiSelection = true;
-            if (self.multiSelectionForward) {
-                polyline.finalIdx++;
-            }
+            polyline.finalIdx++;
             self.multiSelectionForward = true;
         }
     };
@@ -426,9 +433,7 @@ var GooglePolylines = /** @class */ (function () {
         }
         else {
             self.multiSelection = true;
-            if (!self.multiSelectionForward) {
-                polyline.initialIdx--;
-            }
+            polyline.initialIdx--;
             self.multiSelectionForward = false;
         }
     };
@@ -498,7 +503,9 @@ var GooglePolylines = /** @class */ (function () {
         }
         this.selectedPath.initialIdx = polyline.initialIdx;
         this.selectedPath.finalIdx = polyline.finalIdx;
-        this.drawPopupNavigation(polyline);
+        if (!this.suppressNavigationPopup) {
+            this.drawPopupNavigation(polyline);
+        }
     };
     GooglePolylines.prototype.addPolylineEventMove = function (polyline, eventFunction) {
         polyline.moveListener = function (newEvent, lastEvent) {
@@ -633,6 +640,12 @@ var GooglePolylines = /** @class */ (function () {
                     content: infowindow,
                     latlng: [point.lat(), point.lng()],
                 });
+                if (self.navigationPopupCloseHandler && self.navigateInfoWindow) {
+                    self.google.maps.event.addListenerOnce(self.navigateInfoWindow, 'closeclick', function () {
+                        self.navigateInfoWindow = null;
+                        self.navigationPopupCloseHandler();
+                    });
+                }
             }
         }
     };

--- a/src/models/apis/google/google-polylines.ts
+++ b/src/models/apis/google/google-polylines.ts
@@ -19,6 +19,8 @@ export default class GooglePolylines {
     private navigateByPoint: boolean | null = false;
     private navigationOptions: NavigationOptions | any = {};
     private editModeBlockingMapClick: boolean;
+    private suppressNavigationPopup: boolean = false;
+    private navigationPopupCloseHandler: (() => void) | null = null;
 
     constructor(map: any, google: any, googlePopups: GooglePopups) {
         this.map = map;
@@ -189,7 +191,8 @@ export default class GooglePolylines {
 
     public drawPolylineWithNavigation(
         options: PolylineOptions,
-        eventClick?: any
+        eventClick?: any,
+        onNavigationPopupClose?: () => void
     ) {
         const polyline = this.drawPolyline(options, null);
 
@@ -198,6 +201,7 @@ export default class GooglePolylines {
         this.navigateByPoint = this.navigationOptions
             ? this.navigationOptions.navigateByPoint
             : true;
+        this.navigationPopupCloseHandler = onNavigationPopupClose || null;
         this.addNavigation(polyline);
 
         return polyline;
@@ -329,6 +333,14 @@ export default class GooglePolylines {
         }
         if (this.navigateInfoWindow) {
             this.navigateInfoWindow.close();
+        }
+    }
+
+    public setSuppressNavigationPopup(suppress: boolean) {
+        this.suppressNavigationPopup = suppress;
+        if (suppress && this.navigateInfoWindow) {
+            this.navigateInfoWindow.close();
+            this.navigateInfoWindow = null;
         }
     }
 
@@ -566,9 +578,7 @@ export default class GooglePolylines {
             self.multiSelection = false;
         } else {
             self.multiSelection = true;
-            if (self.multiSelectionForward) {
-                polyline.finalIdx++;
-            }
+            polyline.finalIdx++;
             self.multiSelectionForward = true;
         }
     }
@@ -600,9 +610,7 @@ export default class GooglePolylines {
             self.multiSelection = false;
         } else {
             self.multiSelection = true;
-            if (!self.multiSelectionForward) {
-                polyline.initialIdx--;
-            }
+            polyline.initialIdx--;
             self.multiSelectionForward = false;
         }
     }
@@ -680,7 +688,9 @@ export default class GooglePolylines {
         this.selectedPath.initialIdx = polyline.initialIdx;
         this.selectedPath.finalIdx = polyline.finalIdx;
 
-        this.drawPopupNavigation(polyline);
+        if (!this.suppressNavigationPopup) {
+            this.drawPopupNavigation(polyline);
+        }
     }
 
     private addPolylineEventMove(polyline: any, eventFunction: any) {
@@ -902,6 +912,12 @@ export default class GooglePolylines {
                     content: infowindow,
                     latlng: [point.lat(), point.lng()],
                 });
+                if (self.navigationPopupCloseHandler && self.navigateInfoWindow) {
+                    self.google.maps.event.addListenerOnce(self.navigateInfoWindow, 'closeclick', () => {
+                        self.navigateInfoWindow = null;
+                        self.navigationPopupCloseHandler!();
+                    });
+                }
             }
         }
     }

--- a/src/models/apis/google/google-popup.js
+++ b/src/models/apis/google/google-popup.js
@@ -20,6 +20,11 @@ var GooglePopups = /** @class */ (function () {
         if (options.object) {
             infowindow.object = options.object;
         }
+        if (options.onClose) {
+            self.google.maps.event.addListenerOnce(infowindow, 'closeclick', function () {
+                options.onClose();
+            });
+        }
         return infowindow;
     };
     GooglePopups.prototype.alterPopup = function (popup, options, marker) {

--- a/src/models/apis/google/google-popup.ts
+++ b/src/models/apis/google/google-popup.ts
@@ -27,6 +27,11 @@ export default class GooglePopups {
         if (options.object) {
             infowindow.object = options.object;
         }
+        if (options.onClose) {
+            self.google.maps.event.addListenerOnce(infowindow, 'closeclick', () => {
+                options.onClose!();
+            });
+        }
         return infowindow;
     }
 

--- a/src/models/apis/googleMaps.js
+++ b/src/models/apis/googleMaps.js
@@ -306,9 +306,9 @@ var GoogleMaps = /** @class */ (function () {
         var _a;
         return (_a = this.googlePolylines) === null || _a === void 0 ? void 0 : _a.drawPolyline(options, eventClick);
     };
-    GoogleMaps.prototype.drawPolylineWithNavigation = function (options, eventClick) {
+    GoogleMaps.prototype.drawPolylineWithNavigation = function (options, eventClick, onNavigationPopupClose) {
         var _a;
-        return (_a = this.googlePolylines) === null || _a === void 0 ? void 0 : _a.drawPolylineWithNavigation(options, eventClick);
+        return (_a = this.googlePolylines) === null || _a === void 0 ? void 0 : _a.drawPolylineWithNavigation(options, eventClick, onNavigationPopupClose);
     };
     GoogleMaps.prototype.togglePolylines = function (polylines, show) {
         var _a;
@@ -337,6 +337,10 @@ var GoogleMaps = /** @class */ (function () {
     GoogleMaps.prototype.removePolylineHighlight = function () {
         var _a;
         (_a = this.googlePolylines) === null || _a === void 0 ? void 0 : _a.removePolylineHighlight();
+    };
+    GoogleMaps.prototype.setSuppressNavigationPopup = function (suppress) {
+        var _a;
+        (_a = this.googlePolylines) === null || _a === void 0 ? void 0 : _a.setSuppressNavigationPopup(suppress);
     };
     GoogleMaps.prototype.addPolylineEvent = function (polylines, eventType, eventFunction) {
         var _a;

--- a/src/models/apis/googleMaps.ts
+++ b/src/models/apis/googleMaps.ts
@@ -369,11 +369,13 @@ export default class GoogleMaps implements IMapFunctions {
 
     public drawPolylineWithNavigation(
         options: PolylineOptions,
-        eventClick?: any
+        eventClick?: any,
+        onNavigationPopupClose?: () => void
     ): any {
         return this.googlePolylines?.drawPolylineWithNavigation(
             options,
-            eventClick
+            eventClick,
+            onNavigationPopupClose
         );
     }
 
@@ -406,6 +408,10 @@ export default class GoogleMaps implements IMapFunctions {
 
     public removePolylineHighlight(): void {
         this.googlePolylines?.removePolylineHighlight();
+    }
+
+    public setSuppressNavigationPopup(suppress: boolean): void {
+        this.googlePolylines?.setSuppressNavigationPopup(suppress);
     }
 
     public addPolylineEvent(

--- a/src/models/apis/leaflet.js
+++ b/src/models/apis/leaflet.js
@@ -93,7 +93,7 @@ var Leaflet = /** @class */ (function () {
                         });
                         satelliteURL = "https://server.arcgisonline.com/ArcGIS/rest/services/" +
                             "World_Imagery/MapServer/tile/{z}/{y}/{x}";
-                        satellite = L.tileLayer(satelliteURL, {
+                        satellite = leaflet_1.tileLayer(satelliteURL, {
                             attribution: "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye," +
                                 " Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
                             maxZoom: 18,

--- a/src/models/apis/leaflet.js
+++ b/src/models/apis/leaflet.js
@@ -296,9 +296,9 @@ var Leaflet = /** @class */ (function () {
         var _a;
         return (_a = this.leafletPolylines) === null || _a === void 0 ? void 0 : _a.drawPolyline(options, eventClick);
     };
-    Leaflet.prototype.drawPolylineWithNavigation = function (options, eventClick) {
+    Leaflet.prototype.drawPolylineWithNavigation = function (options, eventClick, onNavigationPopupClose) {
         var _a;
-        return (_a = this.leafletPolylines) === null || _a === void 0 ? void 0 : _a.drawPolylineWithNavigation(options, eventClick);
+        return (_a = this.leafletPolylines) === null || _a === void 0 ? void 0 : _a.drawPolylineWithNavigation(options, eventClick, onNavigationPopupClose);
     };
     Leaflet.prototype.togglePolylines = function (polylines, show) {
         var _a;
@@ -327,6 +327,10 @@ var Leaflet = /** @class */ (function () {
     Leaflet.prototype.removePolylineHighlight = function () {
         var _a;
         (_a = this.leafletPolylines) === null || _a === void 0 ? void 0 : _a.removePolylineHighlight();
+    };
+    Leaflet.prototype.setSuppressNavigationPopup = function (suppress) {
+        var _a;
+        (_a = this.leafletPolylines) === null || _a === void 0 ? void 0 : _a.setSuppressNavigationPopup(suppress);
     };
     Leaflet.prototype.addPolylineEvent = function (polylines, eventType, eventFunction) {
         var _a;

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -91,7 +91,7 @@ export default class Leaflet implements IMapFunctions {
             const satelliteURL =
                 "https://server.arcgisonline.com/ArcGIS/rest/services/" +
                 "World_Imagery/MapServer/tile/{z}/{y}/{x}";
-            const satellite = L.tileLayer(satelliteURL, {
+            const satellite = leaflet.tileLayer(satelliteURL, {
                 attribution:
                     "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye," +
                     " Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",

--- a/src/models/apis/leaflet.ts
+++ b/src/models/apis/leaflet.ts
@@ -372,11 +372,13 @@ export default class Leaflet implements IMapFunctions {
 
     public drawPolylineWithNavigation(
         options: PolylineOptions,
-        eventClick?: any
+        eventClick?: any,
+        onNavigationPopupClose?: () => void
     ): any {
         return this.leafletPolylines?.drawPolylineWithNavigation(
             options,
-            eventClick
+            eventClick,
+            onNavigationPopupClose
         );
     }
 
@@ -409,6 +411,10 @@ export default class Leaflet implements IMapFunctions {
 
     public removePolylineHighlight(): void {
         this.leafletPolylines?.removePolylineHighlight();
+    }
+
+    public setSuppressNavigationPopup(suppress: boolean): void {
+        this.leafletPolylines?.setSuppressNavigationPopup(suppress);
     }
 
     public addPolylineEvent(

--- a/src/models/apis/leaflet/leaflet-polylines.js
+++ b/src/models/apis/leaflet/leaflet-polylines.js
@@ -14,6 +14,7 @@ var LeafletPolylines = /** @class */ (function () {
         this.multiSelection = false;
         this.navigateByPoint = false;
         this.navigationOptions = {};
+        this.suppressNavigationPopup = false;
         this.map = map;
         this.leaflet = leaflet;
         this.leafletPopup = leafletPopup;
@@ -115,13 +116,14 @@ var LeafletPolylines = /** @class */ (function () {
         }
         return polyline;
     };
-    LeafletPolylines.prototype.drawPolylineWithNavigation = function (options, eventClick) {
+    LeafletPolylines.prototype.drawPolylineWithNavigation = function (options, eventClick, onNavigationPopupClose) {
         var polyline = this.drawPolyline(options, null);
         polyline.navigationHandlerClick = eventClick;
         this.navigationOptions = options.navigateOptions;
         this.navigateByPoint = this.navigationOptions
             ? this.navigationOptions.navigateByPoint
             : true;
+        this.navigationPopupCloseHandler = onNavigationPopupClose || null;
         this.addNavigation(polyline);
         return polyline;
     };
@@ -268,6 +270,13 @@ var LeafletPolylines = /** @class */ (function () {
         }
         document.onkeyup = null;
         document.onkeydown = null;
+    };
+    LeafletPolylines.prototype.setSuppressNavigationPopup = function (suppress) {
+        this.suppressNavigationPopup = suppress;
+        if (suppress && this.navigateInfoWindow) {
+            this.navigateInfoWindow.remove();
+            this.navigateInfoWindow = null;
+        }
     };
     LeafletPolylines.prototype.addPolylineEvent = function (polylines, eventType, eventFunction) {
         var _this = this;
@@ -423,9 +432,7 @@ var LeafletPolylines = /** @class */ (function () {
         }
         else {
             this.multiSelection = true;
-            if (this.multiSelectionForward) {
-                polyline.finalIdx++;
-            }
+            polyline.finalIdx++;
             this.multiSelectionForward = true;
         }
     };
@@ -449,9 +456,7 @@ var LeafletPolylines = /** @class */ (function () {
         }
         else {
             self.multiSelection = true;
-            if (!self.multiSelectionForward) {
-                polyline.initialIdx--;
-            }
+            polyline.initialIdx--;
             self.multiSelectionForward = false;
         }
     };
@@ -492,7 +497,7 @@ var LeafletPolylines = /** @class */ (function () {
         var infowindow = polyline.options.infowindows
             ? polyline.options.infowindows[idx]
             : null;
-        if (infowindow) {
+        if (infowindow && !self.suppressNavigationPopup) {
             var point = polyline.getLatLngs()[idx];
             if (self.navigateInfoWindow) {
                 self.leafletPopup.alterPopup(self.navigateInfoWindow, {
@@ -505,6 +510,14 @@ var LeafletPolylines = /** @class */ (function () {
                     content: infowindow,
                     latlng: [point.lat, point.lng],
                 });
+                if (self.navigationPopupCloseHandler) {
+                    self.map.once('popupclose', function (e) {
+                        if (e.popup === self.navigateInfoWindow) {
+                            self.navigateInfoWindow = null;
+                            self.navigationPopupCloseHandler();
+                        }
+                    });
+                }
             }
         }
     };

--- a/src/models/apis/leaflet/leaflet-polylines.ts
+++ b/src/models/apis/leaflet/leaflet-polylines.ts
@@ -20,6 +20,8 @@ export default class LeafletPolylines {
     private navigateByPoint: boolean = false;
     private navigationOptions: NavigationOptions | any = {};
     private editModeBlockingMapClick: boolean;
+    private suppressNavigationPopup: boolean = false;
+    private navigationPopupCloseHandler: (() => void) | null = null;
 
     constructor(map: any, leaflet: any, leafletPopup: LeafletPopup) {
         this.map = map;
@@ -174,7 +176,8 @@ export default class LeafletPolylines {
 
     public drawPolylineWithNavigation(
         options: PolylineOptions,
-        eventClick?: any
+        eventClick?: any,
+        onNavigationPopupClose?: () => void
     ) {
         const polyline = this.drawPolyline(options, null);
 
@@ -183,6 +186,7 @@ export default class LeafletPolylines {
         this.navigateByPoint = this.navigationOptions
             ? this.navigationOptions.navigateByPoint
             : true;
+        this.navigationPopupCloseHandler = onNavigationPopupClose || null;
         this.addNavigation(polyline);
         return polyline;
     }
@@ -373,6 +377,14 @@ export default class LeafletPolylines {
         document.onkeydown = null;
     }
 
+    public setSuppressNavigationPopup(suppress: boolean) {
+        this.suppressNavigationPopup = suppress;
+        if (suppress && this.navigateInfoWindow) {
+            this.navigateInfoWindow.remove();
+            this.navigateInfoWindow = null;
+        }
+    }
+
     public addPolylineEvent(
         polylines: any,
         eventType: PolylineEventType,
@@ -560,9 +572,7 @@ export default class LeafletPolylines {
             this.multiSelection = false;
         } else {
             this.multiSelection = true;
-            if (this.multiSelectionForward) {
-                polyline.finalIdx++;
-            }
+            polyline.finalIdx++;
             this.multiSelectionForward = true;
         }
     }
@@ -590,9 +600,7 @@ export default class LeafletPolylines {
             self.multiSelection = false;
         } else {
             self.multiSelection = true;
-            if (!self.multiSelectionForward) {
-                polyline.initialIdx--;
-            }
+            polyline.initialIdx--;
             self.multiSelectionForward = false;
         }
     }
@@ -641,7 +649,7 @@ export default class LeafletPolylines {
         const infowindow = polyline.options.infowindows
             ? polyline.options.infowindows[idx]
             : null;
-        if (infowindow) {
+        if (infowindow && !this.suppressNavigationPopup) {
             const point = polyline.getLatLngs()[idx];
 
             if (self.navigateInfoWindow) {
@@ -654,6 +662,14 @@ export default class LeafletPolylines {
                     content: infowindow,
                     latlng: [point.lat, point.lng],
                 });
+                if (self.navigationPopupCloseHandler) {
+                    self.map.once('popupclose', (e: any) => {
+                        if (e.popup === self.navigateInfoWindow) {
+                            self.navigateInfoWindow = null;
+                            self.navigationPopupCloseHandler!();
+                        }
+                    });
+                }
             }
         }
     }

--- a/src/models/apis/leaflet/leaflet-popup.js
+++ b/src/models/apis/leaflet/leaflet-popup.js
@@ -20,6 +20,13 @@ var LeafletPopup = /** @class */ (function () {
         if (options.object) {
             popup.object = options.object;
         }
+        if (options.onClose) {
+            self.map.once('popupclose', function (e) {
+                if (e.popup === popup) {
+                    options.onClose();
+                }
+            });
+        }
         return popup;
     };
     LeafletPopup.prototype.alterPopup = function (popup, options, marker) {

--- a/src/models/apis/leaflet/leaflet-popup.ts
+++ b/src/models/apis/leaflet/leaflet-popup.ts
@@ -26,6 +26,13 @@ export default class LeafletPopup {
         if (options.object) {
             popup.object = options.object;
         }
+        if (options.onClose) {
+            self.map.once('popupclose', (e: any) => {
+                if (e.popup === popup) {
+                    options.onClose!();
+                }
+            });
+        }
         return popup;
     }
 

--- a/src/models/apis/mapFunctions.ts
+++ b/src/models/apis/mapFunctions.ts
@@ -102,6 +102,7 @@ export default interface IMapFunctions {
     addPolylinePath(polylines: any, position: number[]): void;
     getPolylinePath(polyline: any): number[][];
     removePolylineHighlight(): void;
+    setSuppressNavigationPopup(suppress: boolean): void;
     addPolylineEvent(
         polyline: any,
         event: PolylineEventType,

--- a/src/models/features/popup/popup-options.js
+++ b/src/models/features/popup/popup-options.js
@@ -1,11 +1,12 @@
 var PopupOptions = /** @class */ (function () {
-    function PopupOptions(latlng, content, marker, conditionMarker, notCalledByMap, object) {
+    function PopupOptions(latlng, content, marker, conditionMarker, notCalledByMap, object, onClose) {
         this.latlng = latlng;
         this.content = content;
         this.marker = marker;
         this.conditionMarker = conditionMarker;
         this.notCalledByMap = notCalledByMap;
         this.object = object;
+        this.onClose = onClose;
     }
     return PopupOptions;
 }());

--- a/src/models/features/popup/popup-options.ts
+++ b/src/models/features/popup/popup-options.ts
@@ -5,14 +5,16 @@ export default class PopupOptions {
     public conditionMarker?: any;
     public notCalledByMap?: boolean; /* Property to set if open is called from map event or not, only used on leaflet */
     public object?: object;
+    public onClose?: () => void;
 
     constructor(latlng: number[], content: string, marker?: string, conditionMarker?: any,
-        notCalledByMap?: boolean, object?: object) {
+        notCalledByMap?: boolean, object?: object, onClose?: () => void) {
         this.latlng = latlng;
         this.content = content;
         this.marker = marker;
         this.conditionMarker = conditionMarker;
         this.notCalledByMap = notCalledByMap;
         this.object = object;
+        this.onClose = onClose;
     }
 }


### PR DESCRIPTION
… callbacks de fechamento

- Adiciona setSuppressNavigationPopup() para controlar exibição da popup nativa durante navegação por teclas
- Corrige bug na navegação multiselection: ao inverter direção (Shift+Seta), o índice agora se move imediatamente sem desperdiçar o primeiro keypress
- Adiciona onNavigationPopupClose como 3º parâmetro de drawPolylineWithNavigation: callback disparado ao fechar a popup de navegação
- Adiciona onClose em PopupOptions: callback disparado ao fechar qualquer popup desenhada via drawPopup (Leaflet via popupclose, Google via closeclick)
- Aplica todas as mudanças nos arquivos .ts (fonte) e .js (compilado) para Leaflet e Google Maps